### PR TITLE
Increase coverage

### DIFF
--- a/contrib/gen_coverage.sh
+++ b/contrib/gen_coverage.sh
@@ -6,6 +6,7 @@ if ! command -v grcov &>/dev/null; then
     cargo install grcov
 fi
 
+cargo clean
 CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests" RUSTDOCFLAGS="$RUSTFLAGS" cargo +nightly test
 grcov ./target/debug/ --source-dir . -t html --branch --ignore-not-existing --llvm -o ./target/grcov/
 firefox target/grcov/index.html

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -303,6 +303,8 @@ mod tests {
             .map(|_| get_random_pubkey())
             .collect::<Vec<PublicKey>>();
         assert_eq!(default_vault_descriptor(&participants), Err(RevaultError::ScriptCreation("Vault policy compilation error: Atleast one spending path has more op codes executed than MAX_OPS_PER_SCRIPT".to_string())));
+        // For the sake of test coverage: we should get the same error with CPFP policy
+        assert_eq!(unvault_cpfp_descriptor(&participants), Err(RevaultError::ScriptCreation("Unvault CPFP policy compilation error: Atleast one spending path has more op codes executed than MAX_OPS_PER_SCRIPT".to_string())));
 
         // Maximum non-managers for 2 managers (+ 1)
         let managers = (0..2)


### PR DESCRIPTION
This is based on #5 and increases the code coverage at best effort: everything remaining is either false positives (error.rs, enums, ureachable!()) or intractable.