### PR TITLE
Extended public keys support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [dependencies]
 bitcoin = "0.24"
 bitcoinconsensus = "0.19.0-1"
-secp256k1 = { version = "0.18.0" }
 miniscript = { git = "https://github.com/rust-bitcoin/rust-miniscript", branch = "master", features = ["compiler"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 
 
 [dependencies]
-bitcoin = { git = "https://github.com/darosior/rust-bitcoin", branch = "hack_sighashcache" }
+bitcoin = "0.24"
 bitcoinconsensus = "0.19.0-1"
-miniscript = { git = "https://github.com/darosior/rust-miniscript", branch = "hack_sighashcache", features = ["compiler"] }
-secp256k1 = { version = "0.17.2" }
+secp256k1 = { version = "0.18.0" }
+miniscript = { git = "https://github.com/rust-bitcoin/rust-miniscript", branch = "master", features = ["compiler"] }
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revault"
+name = "revault_tx"
 version = "0.0.1"
 authors = ["Antoine Poinsot <darosior@protonmail.com>"]
 edition = "2018"

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -22,7 +22,7 @@ use miniscript::{policy::concrete::Policy, Descriptor, MiniscriptKey, Segwitv0};
 /// ```rust
 /// use revault_tx::scripts;
 /// use bitcoin;
-/// use secp256k1;
+/// use bitcoin::secp256k1;
 ///
 /// let secp = secp256k1::Secp256k1::new();
 /// let secret_key = secp256k1::SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
@@ -86,7 +86,7 @@ pub fn vault_descriptor<Pk: MiniscriptKey>(participants: Vec<Pk>) -> Result<Desc
 /// ```rust
 /// use revault_tx::scripts;
 /// use bitcoin;
-/// use secp256k1;
+/// use bitcoin::secp256k1;
 ///
 /// let secp = secp256k1::Secp256k1::new();
 /// let secret_key = secp256k1::SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
@@ -204,19 +204,19 @@ mod tests {
     use bitcoin::PublicKey;
 
     fn get_random_pubkey() -> PublicKey {
-        let secp = secp256k1::Secp256k1::new();
+        let secp = bitcoin::secp256k1::Secp256k1::new();
         let mut rand_bytes = [0u8; 32];
         // Make rustc happy..
-        let mut secret_key = Err(secp256k1::Error::InvalidSecretKey);
+        let mut secret_key = Err(bitcoin::secp256k1::Error::InvalidSecretKey);
 
         while secret_key.is_err() {
             rand::thread_rng().fill_bytes(&mut rand_bytes);
-            secret_key = secp256k1::SecretKey::from_slice(&rand_bytes);
+            secret_key = bitcoin::secp256k1::SecretKey::from_slice(&rand_bytes);
         }
 
         PublicKey {
             compressed: true,
-            key: secp256k1::PublicKey::from_secret_key(&secp, &secret_key.unwrap()),
+            key: bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &secret_key.unwrap()),
         }
     }
 

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -21,7 +21,7 @@ use miniscript::{policy::concrete::Policy, Descriptor, Segwitv0};
 ///
 /// # Examples
 /// ```rust
-/// use revault::scripts;
+/// use revault_tx::scripts;
 /// use bitcoin;
 /// use secp256k1;
 ///
@@ -88,7 +88,7 @@ pub fn vault_descriptor(participants: &[PublicKey]) -> Result<Descriptor<PublicK
 ///
 /// # Examples
 /// ```rust
-/// use revault::scripts;
+/// use revault_tx::scripts;
 /// use bitcoin;
 /// use secp256k1;
 ///

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -812,12 +812,12 @@ mod tests {
 
         // Get the script descriptors for the txos we're going to create
         let unvault_descriptor =
-            unvault_descriptor(&non_managers, &managers, &cosigners, CSV_VALUE)
+            unvault_descriptor(non_managers.clone(), managers.clone(), cosigners, CSV_VALUE)
                 .expect("Unvault descriptor generation error");
-        let cpfp_descriptor =
-            unvault_cpfp_descriptor(&managers).expect("Unvault CPFP descriptor generation error");
+        let cpfp_descriptor = unvault_cpfp_descriptor(managers.clone())
+            .expect("Unvault CPFP descriptor generation error");
         let vault_descriptor = vault_descriptor(
-            &managers
+            managers
                 .into_iter()
                 .chain(non_managers.into_iter())
                 .collect::<Vec<PublicKey>>(),

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -278,7 +278,7 @@ fn sighash(
     is_anyonecanpay: bool,
 ) -> SigHash {
     // FIXME: cache the cache for when the user has too much cash
-    let mut cache = SigHashCache::new(&tx);
+    let mut cache = SigHashCache::new(tx);
     cache.signature_hash(
         input_index,
         &script_code,
@@ -898,7 +898,7 @@ mod tests {
         let emergency_tx_sighash_feebump = emergency_tx.signature_hash(
             1,
             &feebump_txout,
-            &feebump_descriptor.script_code().unwrap(),
+            &feebump_descriptor.script_code(),
             false,
         );
         satisfy_transaction_input(
@@ -958,12 +958,9 @@ mod tests {
             true,
         )
         .expect("Satisfying cancel transaction");
-        let cancel_tx_sighash_feebump = cancel_tx.signature_hash(
-            1,
-            &feebump_txout,
-            &feebump_descriptor.script_code().unwrap(),
-            false,
-        );
+        let cancel_tx_sighash_feebump =
+            cancel_tx.signature_hash(1, &feebump_txout, &feebump_descriptor.script_code(), false);
+
         satisfy_transaction_input(
             &secp,
             &mut cancel_tx,
@@ -1007,7 +1004,7 @@ mod tests {
         let unemer_tx_sighash_feebump = unemergency_tx.signature_hash(
             1,
             &feebump_txout,
-            &feebump_descriptor.script_code().unwrap(),
+            &feebump_descriptor.script_code(),
             false,
         );
         satisfy_transaction_input(


### PR DESCRIPTION
This:
- Renames the crate
- Updates to rust-bitcoin 0.24 :tada:
- Updates rust-miniscript to https://github.com/rust-bitcoin/rust-miniscript/pull/131 and move our Miniscripts to use `DescriptorPublicKey`s