### PR TITLE
The Big Refactor :tm:

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,17 +69,6 @@ jobs:
           parallel: true
           path-to-lcov: ${{ steps.coverage.outputs.report }}
 
-
-  grcov_finalize:
-    runs-on: ubuntu-latest
-    needs: grcov
-    steps:
-      - name: Coveralls finalization
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
-
   rustfmt_check:
     runs-on: ubuntu-latest
     steps:

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,12 +7,8 @@ use std::{error, fmt};
 /// An error specific to the management of Revault transactions and scripts.
 #[derive(PartialEq, Eq, Debug)]
 pub enum Error {
-    /// The transaction creation failed.
-    TransactionCreation(String),
     /// The script creation failed.
     ScriptCreation(String),
-    /// Signature-related errors (sighash, ..).
-    Signature(String),
     /// Miniscript satisfaction of a Revault transaction input failed.
     InputSatisfaction(String),
     /// The verification of the transaction against libbitcoinconsensus failed.
@@ -22,11 +18,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::TransactionCreation(ref e) => {
-                write!(f, "Revault transaction creation error: {}", e)
-            }
             Error::ScriptCreation(ref e) => write!(f, "Revault script creation error: {}", e),
-            Error::Signature(ref e) => write!(f, "Revault transaction signature error: {}", e),
             Error::InputSatisfaction(ref e) => write!(f, "Revault input satisfaction error: {}", e),
             Error::TransactionVerification(ref e) => {
                 write!(f, "Revault transaction verification error: {}", e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,8 @@ pub mod error;
 
 pub mod scripts;
 
+pub mod prevouts;
+
+pub mod txouts;
+
 pub mod transactions;

--- a/src/prevouts.rs
+++ b/src/prevouts.rs
@@ -1,0 +1,56 @@
+//! Revault prevouts
+//! Tiny newtype wrappers around bitcoin's OutPoint to statically check Revault transaction
+//! creation.
+
+use bitcoin::OutPoint;
+
+use std::fmt;
+
+/// A transaction output spent by a Revault transaction.
+pub trait RevaultPrevout: fmt::Debug + Copy {
+    /// Get the actual outpoint
+    fn outpoint(&self) -> OutPoint;
+}
+
+macro_rules! implem_revault_prevout {
+    ( $struct_name:ident, $doc_comment:meta ) => {
+        #[$doc_comment]
+        #[derive(Debug, Copy, Clone)]
+        pub struct $struct_name(OutPoint);
+
+        impl $struct_name {
+            /// Create a new prevout, the sequence will be set to 0xff_ff_ff_ff is None
+            pub fn new(outpoint: OutPoint) -> $struct_name {
+                $struct_name(outpoint)
+            }
+        }
+
+        impl RevaultPrevout for $struct_name {
+            fn outpoint(&self) -> OutPoint {
+                self.0
+            }
+        }
+    };
+}
+
+implem_revault_prevout!(
+    VaultPrevout,
+    doc = "A vault txo spent by the unvault transaction and the emergency transaction"
+);
+
+implem_revault_prevout!(
+    UnvaultPrevout,
+    doc="An unvault txo spent by the cancel transaction, an emergency transaction, and the spend transaction."
+);
+
+implem_revault_prevout!(
+    FeeBumpPrevout,
+    doc = "A wallet txo spent by a revaulting (cancel, emergency) transaction to bump the transaction feerate.\
+           This output is often created by a first stage transaction, but may directly be a wallet\
+           utxo."
+);
+
+implem_revault_prevout!(
+    CpfpPrevout,
+    doc = "The unvault CPFP txo spent to accelerate the confirmation of the unvault transaction."
+);

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -50,7 +50,8 @@ pub fn vault_descriptor(participants: &[PublicKey]) -> Result<Descriptor<PublicK
 
     let pubkeys = participants
         .iter()
-        .map(|pubkey| Policy::Key(*pubkey))
+        .copied()
+        .map(Policy::Key)
         .collect::<Vec<Policy<PublicKey>>>();
 
     // Note that this will be more optimal once
@@ -138,19 +139,22 @@ pub fn unvault_descriptor(
 
     let mut pubkeys = managers
         .iter()
-        .map(|pubkey| Policy::Key(*pubkey))
+        .copied()
+        .map(Policy::Key)
         .collect::<Vec<Policy<PublicKey>>>();
     let spenders_thres = Policy::Threshold(pubkeys.len(), pubkeys);
 
     pubkeys = non_managers
         .iter()
-        .map(|pubkey| Policy::Key(*pubkey))
+        .copied()
+        .map(Policy::Key)
         .collect::<Vec<Policy<PublicKey>>>();
     let non_spenders_thres = Policy::Threshold(pubkeys.len(), pubkeys);
 
     pubkeys = cosigners
         .iter()
-        .map(|pubkey| Policy::Key(*pubkey))
+        .copied()
+        .map(Policy::Key)
         .collect::<Vec<Policy<PublicKey>>>();
     let cosigners_thres = Policy::Threshold(pubkeys.len(), pubkeys);
 
@@ -181,7 +185,8 @@ pub fn unvault_descriptor(
 pub fn unvault_cpfp_descriptor(managers: &[PublicKey]) -> Result<Descriptor<PublicKey>, Error> {
     let pubkeys = managers
         .iter()
-        .map(|pubkey| Policy::Key(*pubkey))
+        .copied()
+        .map(Policy::Key)
         .collect::<Vec<Policy<PublicKey>>>();
 
     let policy = Policy::Threshold(1, pubkeys);

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2,7 +2,7 @@
 //!
 //! Typesafe routines to create bare revault transactions.
 
-use crate::error::Error;
+use crate::{error::Error, prevouts::*, txouts::*};
 
 use bitcoin::consensus::encode;
 use bitcoin::consensus::encode::Encodable;
@@ -12,457 +12,44 @@ use miniscript::{BitcoinSig, Descriptor, MiniscriptKey, Satisfier, ToPublicKey};
 use secp256k1::Signature;
 
 use std::collections::HashMap;
-use std::io;
+use std::fmt;
 
-const RBF_SEQUENCE: u32 = u32::MAX - 2;
-
-/// A transaction output created by a Revault transaction.
-#[derive(PartialEq, Eq, Debug, Clone, Hash)]
-pub enum RevaultTxOut {
-    /// A vault transaction output. Used by the funding / deposit transactions, the cancel
-    /// transactions, and the spend transactions (for the change).
-    VaultTxOut(TxOut),
-    /// *The* unvault transaction output.
-    UnvaultTxOut(TxOut),
-    /// A spend transaction output. As Revault is flexible by default with regard to the
-    /// destination of the spend transaction funds, any number of these can be present in a spend
-    /// transaction (use a VaultTxOut for the change output however).
-    SpendTxOut(TxOut),
-    /// The Emergency Deep Vault, the destination of the emergency transactions fund.
-    EmergencyTxOut(TxOut),
-    /// The output attached to the unvault transaction so that the fund managers can
-    /// CPFP.
-    CpfpTxOut(TxOut),
-    /// The output spent by the revaulting transactions to bump their feerate
-    FeeBumpTxOut(TxOut),
-    /// An untagged external output, spent by the vault transaction
-    ExternalTxOut(TxOut),
-}
-
-/// A transaction output spent by a Revault transaction.
-#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash, PartialOrd, Ord)]
-pub enum RevaultPrevout {
-    /// A vault txo spent by the unvault transaction and the emergency transaction.
-    VaultPrevout(OutPoint),
-    /// An unvault txo spent by the cancel transaction, an emergency transaction, and
-    /// the spend transaction.
-    UnvaultPrevout(OutPoint),
-    /// A wallet txo spent by a revaulting (cancel, emergency) transaction to bump the
-    /// transaction feerate.
-    /// This output is often created by a first stage transaction, but may directly be a wallet
-    /// utxo.
-    FeeBumpPrevout(OutPoint),
-    /// The unvault CPFP txo spent to accelerate the confirmation of the unvault transaction.
-    CpfpPrevout(OutPoint),
-}
-
-// Using a struct wrapper around the enum wrapper to create an encapsulation behaviour would be
-// quite verbose..
+/// TxIn's sequence to set for the tx to be bip125-replaceable
+pub const RBF_SEQUENCE: u32 = u32::MAX - 2;
 
 /// A Revault transaction. Apart from the VaultTransaction, all variants must be instanciated
 /// using the new_*() methods.
-#[derive(PartialEq, Eq, Debug)]
-pub enum RevaultTransaction {
-    /// The funding transaction, we don't create it but it's a handy wrapper.
-    VaultTransaction(Transaction),
-    /// The unvaulting transaction, spending a vault and being eventually spent by a spend
-    /// transaction (if not revaulted).
-    UnvaultTransaction(Transaction),
-    /// The transaction spending the unvaulting transaction, paying to one or multiple
-    /// externally-controlled addresses, and possibly to a new vault txo for the change.
-    SpendTransaction(Transaction),
-    /// The transaction "revaulting" a spend attempt, i.e. spending the unvaulting transaction back
-    /// to a vault txo.
-    CancelTransaction(Transaction),
-    /// The transaction spending either a vault or unvault txo to The Emergency Deep Vault.
-    EmergencyTransaction(Transaction),
-    /// The fee-bumping transaction, we don't create it but it may be passed to verify()
-    FeeBumpTransaction(Transaction),
-}
+pub trait RevaultTransaction: fmt::Debug {
+    /// Get the inner transaction
+    fn inner_tx(&self) -> &Transaction;
 
-impl RevaultTransaction {
-    /// Create an unvault transaction.
-    /// An unvault transaction always spends one vault txout and contains one CPFP txout in
-    /// addition to the unvault one.
-    ///
-    /// # Errors
-    /// - If prevouts or txouts type mismatch.
-    pub fn new_unvault(
-        prevouts: &[RevaultPrevout; 1],
-        txouts: &[RevaultTxOut; 2],
-    ) -> Result<RevaultTransaction, Error> {
-        match (prevouts, txouts) {
-            (
-                [RevaultPrevout::VaultPrevout(ref vault_prevout)],
-                [RevaultTxOut::UnvaultTxOut(ref unvault_txout), RevaultTxOut::CpfpTxOut(ref cpfp_txout)],
-            ) => {
-                let vault_input = TxIn {
-                    previous_output: *vault_prevout,
-                    ..Default::default()
-                };
-                Ok(RevaultTransaction::UnvaultTransaction(Transaction {
-                    version: 2,
-                    lock_time: 0, // FIXME: anti fee snipping
-                    input: vec![vault_input],
-                    output: vec![unvault_txout.clone(), cpfp_txout.clone()],
-                }))
-            }
-            _ => Err(Error::TransactionCreation(format!(
-                "Unvault: type mismatch on prevout ({:?}) or output(s) ({:?})",
-                prevouts, txouts
-            ))),
-        }
-    }
-
-    /// Create a new spend transaction.
-    /// A spend transaction can batch multiple unvault txouts, and may have any number of
-    /// txouts (including, but not restricted to, change).
-    ///
-    /// # Errors
-    /// - If prevouts or txouts type mismatch.
-    pub fn new_spend(
-        prevouts: &[RevaultPrevout],
-        outputs: &[RevaultTxOut],
-        csv_value: u32,
-    ) -> Result<RevaultTransaction, Error> {
-        let mut txins = Vec::<TxIn>::with_capacity(prevouts.len());
-        for prevout in prevouts {
-            if let RevaultPrevout::UnvaultPrevout(ref prev) = prevout {
-                txins.push(TxIn {
-                    previous_output: *prev,
-                    sequence: csv_value,
-                    ..TxIn::default()
-                })
-            } else {
-                return Err(Error::TransactionCreation(format!(
-                    "Spend: prevout ({:?}) type mismatch",
-                    prevout
-                )));
-            }
-        }
-
-        let mut txouts = Vec::<TxOut>::with_capacity(outputs.len());
-        for out in outputs {
-            match out {
-                RevaultTxOut::SpendTxOut(ref txout) | RevaultTxOut::VaultTxOut(ref txout) => {
-                    txouts.push(txout.clone())
-                }
-                _ => {
-                    return Err(Error::TransactionCreation(format!(
-                        "Spend: output ({:?}) type mismatch",
-                        out
-                    )))
-                }
-            }
-        }
-
-        Ok(RevaultTransaction::SpendTransaction(Transaction {
-            version: 2,
-            lock_time: 0,
-            input: txins,
-            output: txouts,
-        }))
-    }
-
-    /// Create a new cancel transaction.
-    /// A cancel transaction always pays to a vault output and spend the unvault output, and
-    /// may have a fee-bumping input.
-    ///
-    /// # Errors
-    /// - If prevouts or txouts type mismatch.
-    pub fn new_cancel(
-        prevouts: &[RevaultPrevout],
-        txouts: &[RevaultTxOut],
-    ) -> Result<RevaultTransaction, Error> {
-        match (prevouts, txouts) {
-            // FIXME: Use https://github.com/rust-lang/rust/issues/54883 once stabilized ..
-            (
-                &[RevaultPrevout::UnvaultPrevout(_)],
-                &[RevaultTxOut::VaultTxOut(ref vault_txout)],
-            )
-            | (
-                &[RevaultPrevout::UnvaultPrevout(_), RevaultPrevout::FeeBumpPrevout(_)],
-                &[RevaultTxOut::VaultTxOut(ref vault_txout)],
-            ) => {
-                let inputs = prevouts
-                    .iter()
-                    .map(|prevout| TxIn {
-                        previous_output: match prevout {
-                            RevaultPrevout::UnvaultPrevout(ref prev)
-                            | RevaultPrevout::FeeBumpPrevout(ref prev) => *prev,
-                            _ => unreachable!(),
-                        },
-                        sequence: RBF_SEQUENCE,
-                        ..Default::default()
-                    })
-                    .collect();
-
-                Ok(RevaultTransaction::CancelTransaction(Transaction {
-                    version: 2,
-                    lock_time: 0,
-                    input: inputs,
-                    output: vec![vault_txout.clone()],
-                }))
-            }
-            _ => Err(Error::TransactionCreation(format!(
-                "Cancel: prevout(s) ({:?}) or output(s) ({:?}) type mismatch",
-                prevouts, txouts,
-            ))),
-        }
-    }
-
-    /// Create an emergency transaction.
-    /// There are two emergency transactions, one spending the vault output and one spending
-    /// the unvault output. Both may have a fee-bumping input.
-    ///
-    /// # Errors
-    /// - If prevouts or txouts type mismatch.
-    pub fn new_emergency(
-        prevouts: &[RevaultPrevout],
-        txouts: &[RevaultTxOut],
-    ) -> Result<RevaultTransaction, Error> {
-        // FIXME: Use https://github.com/rust-lang/rust/issues/54883 once stabilized ..
-        match (prevouts, txouts) {
-            (
-                &[RevaultPrevout::VaultPrevout(_)],
-                &[RevaultTxOut::EmergencyTxOut(ref emer_txout)],
-            )
-            | (
-                &[RevaultPrevout::VaultPrevout(_), RevaultPrevout::FeeBumpPrevout(_)],
-                &[RevaultTxOut::EmergencyTxOut(ref emer_txout)],
-            )
-            | (
-                &[RevaultPrevout::UnvaultPrevout(_)],
-                &[RevaultTxOut::EmergencyTxOut(ref emer_txout)],
-            )
-            | (
-                &[RevaultPrevout::UnvaultPrevout(_), RevaultPrevout::FeeBumpPrevout(_)],
-                &[RevaultTxOut::EmergencyTxOut(ref emer_txout)],
-            ) => {
-                let inputs = prevouts
-                    .iter()
-                    .map(|prevout| TxIn {
-                        previous_output: match prevout {
-                            RevaultPrevout::VaultPrevout(ref prev)
-                            | RevaultPrevout::UnvaultPrevout(ref prev)
-                            | RevaultPrevout::FeeBumpPrevout(ref prev) => *prev,
-                            _ => unreachable!(),
-                        },
-                        sequence: RBF_SEQUENCE,
-                        ..Default::default()
-                    })
-                    .collect();
-
-                Ok(RevaultTransaction::EmergencyTransaction(Transaction {
-                    version: 2,
-                    lock_time: 0,
-                    input: inputs,
-                    output: vec![emer_txout.clone()],
-                }))
-            }
-            _ => Err(Error::TransactionCreation(format!(
-                "Emergency: prevout(s) ({:?}) or output(s) ({:?}) type mismatch",
-                prevouts, txouts,
-            ))),
-        }
-    }
-
-    // It's private on purpose: accessing the inner tx should either be done by using the provided
-    // methods (or adding new ones to be reused), or by careful pattern matching.
-    fn inner_tx(&self) -> &Transaction {
-        match *self {
-            RevaultTransaction::VaultTransaction(ref tx)
-            | RevaultTransaction::UnvaultTransaction(ref tx)
-            | RevaultTransaction::SpendTransaction(ref tx)
-            | RevaultTransaction::CancelTransaction(ref tx)
-            | RevaultTransaction::EmergencyTransaction(ref tx)
-            | RevaultTransaction::FeeBumpTransaction(ref tx) => tx,
-        }
-    }
-
-    /// Get the network-serialized (inner) transaction
-    pub fn serialize(&self) -> Vec<u8> {
-        encode::serialize(&*self)
-    }
+    /// Get the inner transaction
+    fn inner_tx_mut(&mut self) -> &mut Transaction;
 
     /// Get the specified output of this transaction as an OutPoint to be referenced
     /// in a following transaction.
-    /// Mainly useful to avoid the destructuring boilerplate.
-    pub fn prevout(&self, vout: u32) -> OutPoint {
+    fn into_prevout(&self, vout: u32) -> OutPoint {
         OutPoint {
             txid: self.inner_tx().txid(),
             vout,
         }
     }
 
-    /// Get the sighash for any RevaultTransaction input.
-    /// This is a wrapper around rust-bitcoin's `signature_hash()` but as we only ever sign
-    /// transaction with ALL or ALL|ANYONECANPAY we don't need to be generalistic with choosing
-    /// the type.
-    ///
-    /// # Errors
-    /// - If the previous output type mismatch.
-    pub fn signature_hash(
-        &self,
-        input_index: usize,
-        previous_txout: &RevaultTxOut,
-        script_code: &Script,
-        is_anyonecanpay: bool,
-    ) -> Result<SigHash, Error> {
-        // Called if types match
-        fn sighash(
-            tx: &Transaction,
-            input_index: usize,
-            previous_txout: &TxOut,
-            script_code: &Script,
-            is_anyonecanpay: bool,
-        ) -> SigHash {
-            let mut cache = SigHashCache::new(&tx);
-            if is_anyonecanpay {
-                return cache.signature_hash(
-                    input_index,
-                    &script_code,
-                    previous_txout.value,
-                    SigHashType::AllPlusAnyoneCanPay,
-                );
-            }
-            cache.signature_hash(
-                input_index,
-                &script_code,
-                previous_txout.value,
-                SigHashType::All,
-            )
-        }
-
-        match *self {
-            RevaultTransaction::VaultTransaction(ref tx)
-            | RevaultTransaction::FeeBumpTransaction(ref tx) => match previous_txout {
-                RevaultTxOut::ExternalTxOut(ref txo) => Ok(
-                    sighash(&tx, input_index, &txo, &script_code, is_anyonecanpay)
-                ),
-                _ => Err(
-                    Error::Signature(
-                        "Wrong transaction output type: vault and fee-buming transactions only spend external utxos"
-                        .to_string()
-                    )
-                ),
-            }
-            RevaultTransaction::UnvaultTransaction(ref tx) => match previous_txout {
-                RevaultTxOut::VaultTxOut(ref txo) => Ok(
-                    sighash(&tx, input_index, &txo, &script_code, is_anyonecanpay)
-                ),
-                _ => Err(
-                    Error::Signature(
-                        "Wrong transaction output type: unvault transactions only spend vault transactions"
-                        .to_string()
-                    )
-                ),
-            },
-            RevaultTransaction::SpendTransaction(ref tx) => match previous_txout {
-                RevaultTxOut::UnvaultTxOut(ref txo) => Ok(
-                    sighash(&tx, input_index, &txo, &script_code, is_anyonecanpay)
-                ),
-                _ => Err(
-                    Error::Signature(
-                        "Wrong transaction output type: spend transactions only spend unvault transactions"
-                        .to_string()
-                    )
-                ),
-            },
-            RevaultTransaction::CancelTransaction(ref tx) => match previous_txout {
-                RevaultTxOut::UnvaultTxOut(ref txo)
-                | RevaultTxOut::FeeBumpTxOut(ref txo) => Ok(
-                    sighash(&tx, input_index, &txo, &script_code, is_anyonecanpay)
-                ),
-                _ => Err(
-                    Error::Signature(
-                        "Wrong transaction output type: cancel transactions only spend unvault transactions and fee-bumping transactions"
-                        .to_string()
-                    )
-                ),
-            },
-            RevaultTransaction::EmergencyTransaction(ref tx) => match previous_txout {
-                RevaultTxOut::VaultTxOut(ref txo)
-                | RevaultTxOut::UnvaultTxOut(ref txo)
-                | RevaultTxOut::FeeBumpTxOut(ref txo) => Ok(
-                    sighash(&tx, input_index, &txo, &script_code, is_anyonecanpay)
-                ),
-                _ => Err(
-                    Error::Signature(
-                        "Wrong transaction output type: emergency transactions only spend vault, unvault and fee-bumping transactions"
-                        .to_string()
-                    )
-                ),
-            }
-        }
-    }
-
-    /// Verify this transaction validity against libbitcoinconsensus.
-    /// Handles all the destructuring and txout research internally.
-    ///
-    /// # Errors
-    /// - If verification fails.
-    pub fn verify(&self, previous_transactions: &[&RevaultTransaction]) -> Result<(), Error> {
-        // Look for a referenced txout in the set of spent transactions
-        // TODO: optimize this by walking the previous tx set only once ?
-        fn get_txout(prevout: &OutPoint, transactions: &[&RevaultTransaction]) -> Option<TxOut> {
-            for prev_tx in transactions {
-                match *prev_tx {
-                    RevaultTransaction::VaultTransaction(ref tx)
-                    | RevaultTransaction::UnvaultTransaction(ref tx)
-                    | RevaultTransaction::SpendTransaction(ref tx)
-                    | RevaultTransaction::CancelTransaction(ref tx)
-                    | RevaultTransaction::EmergencyTransaction(ref tx)
-                    | RevaultTransaction::FeeBumpTransaction(ref tx) => {
-                        if tx.txid() == prevout.txid {
-                            if prevout.vout as usize >= tx.output.len() {
-                                return None;
-                            }
-                            return Some(tx.output[prevout.vout as usize].clone());
-                        }
-                    }
-                }
-            }
-
-            None
-        }
-
-        for (index, txin) in self.inner_tx().input.iter().enumerate() {
-            match get_txout(&txin.previous_output, &previous_transactions) {
-                Some(prev_txout) => {
-                    if let Err(err) = bitcoinconsensus::verify(
-                        &prev_txout.script_pubkey.as_bytes(),
-                        prev_txout.value,
-                        self.serialize().as_slice(),
-                        index,
-                    ) {
-                        return Err(Error::TransactionVerification(format!(
-                            "Bitcoinconsensus error: {:?}",
-                            err
-                        )));
-                    }
-                }
-                None => {
-                    return Err(Error::TransactionVerification(format!(
-                        "Unknown txout refered by txin '{:?}'",
-                        txin
-                    )));
-                }
-            }
-        }
-
-        Ok(())
+    /// Get the network-serialized (inner) transaction
+    fn serialize(&self) -> Vec<u8> {
+        // FIXME: this panics...
+        encode::serialize(self.inner_tx())
     }
 
     /// Get the hexadecimal representation of the transaction as used by the bitcoind API.
     ///
     /// # Errors
     /// - If we could not encode the transaction (should not happen).
-    pub fn hex(&self) -> Result<String, Box<dyn std::error::Error>> {
+    fn hex(&self) -> Result<String, Box<dyn std::error::Error>> {
         let mut buff = Vec::<u8>::new();
         let mut as_hex = String::new();
 
-        self.consensus_encode(&mut buff)?;
+        self.inner_tx().consensus_encode(&mut buff)?;
         for byte in buff.into_iter() {
             as_hex.push_str(&format!("{:02x}", byte));
         }
@@ -471,9 +58,343 @@ impl RevaultTransaction {
     }
 }
 
-impl Encodable for RevaultTransaction {
-    fn consensus_encode<S: io::Write>(&self, mut s: S) -> Result<usize, encode::Error> {
-        self.inner_tx().consensus_encode(&mut s)
+// Boilerplate for newtype declaration and small trait helpers implementation.
+macro_rules! impl_revault_transaction {
+    ( $transaction_name:ident, $doc_comment:meta ) => {
+        #[$doc_comment]
+        #[derive(Debug)]
+        pub struct $transaction_name(Transaction);
+
+        impl RevaultTransaction for $transaction_name {
+            fn inner_tx(&self) -> &Transaction {
+                &self.0
+            }
+
+            fn inner_tx_mut(&mut self) -> &mut Transaction {
+                &mut self.0
+            }
+        }
+    };
+}
+
+// Boilerplate for creating an actual (inner) transaction with a known number of prevouts / txouts.
+macro_rules! create_tx {
+    ( [$( ($prevout:expr, $sequence:expr) ),* $(,)?], [$($txout:expr),* $(,)?]) => {
+        Transaction {
+            version: 2,
+            lock_time: 0, // FIXME: anti fee-snipping
+            input: vec![$(
+                TxIn {
+                    previous_output: $prevout.outpoint(),
+                    sequence: $sequence,
+                    ..TxIn::default()
+                },
+            )*],
+            output: vec![$(
+                $txout.get_txout(),
+            )*],
+        }
+    }
+}
+
+impl_revault_transaction!(
+    UnvaultTransaction,
+    doc = "The unvaulting transaction, spending a vault and being eventually spent by a spend transaction (if not revaulted)."
+);
+impl UnvaultTransaction {
+    /// An unvault transaction always spends one vault output and contains one CPFP output in
+    /// addition to the unvault one.
+    pub fn new(
+        vault_input: (VaultPrevout, u32),
+        unvault_txout: UnvaultTxOut,
+        cpfp_txout: CpfpTxOut,
+    ) -> UnvaultTransaction {
+        UnvaultTransaction(create_tx!(
+            [(vault_input.0, vault_input.1)],
+            [unvault_txout, cpfp_txout]
+        ))
+    }
+}
+
+impl_revault_transaction!(
+    CancelTransaction,
+    doc = "The transaction \"revaulting\" a spend attempt, i.e. spending the unvaulting transaction back to a vault txo."
+);
+impl CancelTransaction {
+    /// A cancel transaction always pays to a vault output and spends the unvault output, and
+    /// may have a fee-bumping input.
+    pub fn new(
+        unvault_input: (UnvaultPrevout, u32),
+        feebump_input: Option<(FeeBumpPrevout, u32)>,
+        vault_txout: VaultTxOut,
+    ) -> CancelTransaction {
+        CancelTransaction(if let Some(feebump_input) = feebump_input {
+            create_tx!(
+                [
+                    (unvault_input.0, unvault_input.1),
+                    (feebump_input.0, feebump_input.1)
+                ],
+                [vault_txout]
+            )
+        } else {
+            create_tx!([(unvault_input.0, unvault_input.1)], [vault_txout])
+        })
+    }
+}
+
+impl_revault_transaction!(
+    EmergencyTransaction,
+    doc = "The transaction spending a vault output to The Emergency Script."
+);
+impl EmergencyTransaction {
+    /// The first emergency transaction always spends a vault output and pays to the Emergency
+    /// Script. It may also spend an additional output for fee-bumping.
+    pub fn new(
+        vault_input: (VaultPrevout, u32),
+        feebump_input: Option<(FeeBumpPrevout, u32)>,
+        emer_txout: EmergencyTxOut,
+    ) -> EmergencyTransaction {
+        EmergencyTransaction(if let Some(feebump_input) = feebump_input {
+            create_tx!(
+                [
+                    (vault_input.0, vault_input.1),
+                    (feebump_input.0, feebump_input.1)
+                ],
+                [emer_txout]
+            )
+        } else {
+            create_tx!([(vault_input.0, vault_input.1)], [emer_txout])
+        })
+    }
+}
+
+impl_revault_transaction!(
+    UnvaultEmergencyTransaction,
+    doc = "The transaction spending an unvault output to The Emergency Script."
+);
+impl UnvaultEmergencyTransaction {
+    /// The second emergency transaction always spends an unvault output and pays to the Emergency
+    /// Script. It may also spend an additional output for fee-bumping.
+    pub fn new(
+        unvault_input: (UnvaultPrevout, u32),
+        feebump_input: Option<(FeeBumpPrevout, u32)>,
+        emer_txout: EmergencyTxOut,
+    ) -> UnvaultEmergencyTransaction {
+        UnvaultEmergencyTransaction(if let Some(feebump_input) = feebump_input {
+            create_tx!(
+                [
+                    (unvault_input.0, unvault_input.1),
+                    (feebump_input.0, feebump_input.1)
+                ],
+                [emer_txout]
+            )
+        } else {
+            create_tx!([(unvault_input.0, unvault_input.1)], [emer_txout])
+        })
+    }
+}
+
+impl_revault_transaction!(
+    SpendTransaction,
+    doc = "The transaction spending the unvaulting transaction, paying to one or multiple \
+    externally-controlled addresses, and possibly to a new vault txo for the change."
+);
+impl SpendTransaction {
+    /// A spend transaction can batch multiple unvault txouts, and may have any number of
+    /// txouts (including, but not restricted to, change).
+    pub fn new(
+        unvault_inputs: &[(UnvaultPrevout, u32)],
+        spend_txouts: Vec<SpendTxOut>,
+    ) -> SpendTransaction {
+        SpendTransaction(Transaction {
+            version: 2,
+            lock_time: 0, // FIXME: anti fee-snipping
+            input: unvault_inputs
+                .iter()
+                .map(|input| TxIn {
+                    previous_output: input.0.outpoint(),
+                    sequence: input.1,
+                    ..TxIn::default()
+                })
+                .collect(),
+            output: spend_txouts
+                .into_iter()
+                .map(|spend_txout| match spend_txout {
+                    SpendTxOut::Destination(txo) => txo.get_txout(),
+                    SpendTxOut::Change(txo) => txo.get_txout(),
+                })
+                .collect(),
+        })
+    }
+}
+
+impl_revault_transaction!(
+    VaultTransaction,
+    doc = "The funding transaction, we don't create it but it's a handy wrapper for verify()."
+);
+impl VaultTransaction {
+    /// We don't create nor are able to sign, it's just a type wrapper for verify so explicitly no
+    /// restriction on the types here
+    pub fn new(tx: Transaction) -> VaultTransaction {
+        VaultTransaction(tx)
+    }
+}
+
+impl_revault_transaction!(
+    FeeBumpTransaction,
+    doc = "The fee-bumping transaction, we don't create it but it may be passed to verify()."
+);
+impl FeeBumpTransaction {
+    /// We don't create nor are able to sign, it's just a type wrapper for verify so explicitly no
+    /// restriction on the types here
+    pub fn new(tx: Transaction) -> FeeBumpTransaction {
+        FeeBumpTransaction(tx)
+    }
+}
+
+// Non typesafe sighash boilerplate
+fn sighash(
+    tx: &Transaction,
+    input_index: usize,
+    previous_txout: &TxOut,
+    script_code: &Script,
+    is_anyonecanpay: bool,
+) -> SigHash {
+    // FIXME: cache the cache for when the user has too much cash
+    let mut cache = SigHashCache::new(&tx);
+    cache.signature_hash(
+        input_index,
+        &script_code,
+        previous_txout.value,
+        if is_anyonecanpay {
+            SigHashType::AllPlusAnyoneCanPay
+        } else {
+            SigHashType::All
+        },
+    )
+}
+
+// We use this to configure which txouts types are valid to be used by a given transaction type.
+// This allows to compile-time check that we request a sighash for what is more likely to be a
+// valid Revault transaction.
+macro_rules! impl_valid_prev_txouts {
+    ( $valid_prev_txouts: ident, [$($txout:ident),*], $doc_comment:meta ) => {
+        #[$doc_comment]
+        pub trait $valid_prev_txouts: RevaultTxOut {}
+        $(impl $valid_prev_txouts for $txout {})*
+    };
+}
+
+impl UnvaultTransaction {
+    /// Get a signature hash for an input, previous_txout's type is statically checked to be
+    /// acceptable.
+    pub fn signature_hash(
+        &self,
+        input_index: usize,
+        previous_txout: &VaultTxOut,
+        script_code: &Script,
+    ) -> SigHash {
+        sighash(
+            &self.0,
+            input_index,
+            previous_txout.inner_txout(),
+            script_code,
+            false,
+        )
+    }
+}
+
+impl_valid_prev_txouts!(
+    CancelPrevTxout,
+    [UnvaultTxOut, FeeBumpTxOut],
+    doc = "CancelTransaction can only spend UnvaultTxOut and FeeBumpTxOut txouts"
+);
+impl CancelTransaction {
+    /// Get a signature hash for an input, previous_txout's type is statically checked to be
+    /// acceptable.
+    pub fn signature_hash(
+        &self,
+        input_index: usize,
+        previous_txout: &impl CancelPrevTxout,
+        script_code: &Script,
+        is_anyonecanpay: bool,
+    ) -> SigHash {
+        sighash(
+            &self.0,
+            input_index,
+            previous_txout.inner_txout(),
+            script_code,
+            is_anyonecanpay,
+        )
+    }
+}
+
+impl_valid_prev_txouts!(
+    EmergencyPrevTxout,
+    [VaultTxOut, FeeBumpTxOut],
+    doc = "EmergencyTransaction can only spend UnvaultTxOut and FeeBumpTxOut txouts"
+);
+impl EmergencyTransaction {
+    /// Get a signature hash for an input, previous_txout's type is statically checked to be
+    /// acceptable.
+    pub fn signature_hash(
+        &self,
+        input_index: usize,
+        previous_txout: &impl EmergencyPrevTxout,
+        script_code: &Script,
+        is_anyonecanpay: bool,
+    ) -> SigHash {
+        sighash(
+            &self.0,
+            input_index,
+            previous_txout.inner_txout(),
+            script_code,
+            is_anyonecanpay,
+        )
+    }
+}
+
+impl_valid_prev_txouts!(
+    UnvaultEmerPrevTxout,
+    [UnvaultTxOut, FeeBumpTxOut],
+    doc = "UnvaultEmergencyTransaction can only spend UnvaultTxOut and FeeBumpTxOut txouts."
+);
+impl UnvaultEmergencyTransaction {
+    /// Get a signature hash for an input, previous_txout's type is statically checked to be
+    /// acceptable.
+    fn signature_hash(
+        &self,
+        input_index: usize,
+        previous_txout: &impl UnvaultEmerPrevTxout,
+        script_code: &Script,
+        is_anyonecanpay: bool,
+    ) -> SigHash {
+        sighash(
+            &self.0,
+            input_index,
+            previous_txout.inner_txout(),
+            script_code,
+            is_anyonecanpay,
+        )
+    }
+}
+
+impl SpendTransaction {
+    /// Get a signature hash for an input, previous_txout's type is statically checked to be
+    /// acceptable.
+    pub fn signature_hash(
+        &self,
+        input_index: usize,
+        previous_txout: &UnvaultTxOut,
+        script_code: &Script,
+    ) -> SigHash {
+        sighash(
+            &self.0,
+            input_index,
+            previous_txout.inner_txout(),
+            script_code,
+            false,
+        )
     }
 }
 
@@ -552,32 +473,24 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey> RevaultSatisfier<'a, Pk> {
     /// # Errors
     /// - If the input index is out of bounds.
     pub fn new(
-        transaction: &'a mut RevaultTransaction,
+        transaction: &'a mut impl RevaultTransaction,
         input_index: usize,
         descriptor: &'a Descriptor<Pk>,
     ) -> Result<RevaultSatisfier<'a, Pk>, Error> {
-        let txin = match transaction {
-            RevaultTransaction::VaultTransaction(ref mut tx)
-            | RevaultTransaction::UnvaultTransaction(ref mut tx)
-            | RevaultTransaction::SpendTransaction(ref mut tx)
-            | RevaultTransaction::CancelTransaction(ref mut tx)
-            | RevaultTransaction::EmergencyTransaction(ref mut tx)
-            | RevaultTransaction::FeeBumpTransaction(ref mut tx) => {
-                if input_index >= tx.input.len() {
-                    return Err(Error::InputSatisfaction(format!(
-                        "Input index '{}' out of bounds of the transaction '{:?}'.",
-                        input_index, tx.input
-                    )));
-                }
-                &mut tx.input[input_index]
-            }
-        };
+        let tx = transaction.inner_tx_mut();
+        let txin = tx.input.get_mut(input_index);
+        if let Some(txin) = txin {
+            return Ok(RevaultSatisfier::<Pk> {
+                satisfier: RevaultInputSatisfier::new(txin.sequence),
+                txin,
+                descriptor,
+            });
+        }
 
-        Ok(RevaultSatisfier::<Pk> {
-            satisfier: RevaultInputSatisfier::new(txin.sequence),
-            txin,
-            descriptor,
-        })
+        Err(Error::InputSatisfaction(format!(
+            "Input index '{}' out of bounds.",
+            input_index,
+        )))
     }
 
     /// Insert a signature for a given pubkey to eventually satisfy the spending conditions of the
@@ -609,6 +522,61 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey> RevaultSatisfier<'a, Pk> {
 
         Ok(())
     }
+}
+
+/// Verify this transaction validity against libbitcoinconsensus.
+/// Handles all the destructuring and txout research internally.
+///
+/// # Errors
+/// - If verification fails.
+pub fn verify_revault_transaction(
+    revault_tx: &impl RevaultTransaction,
+    previous_transactions: &[&impl RevaultTransaction],
+) -> Result<(), Error> {
+    // Look for a referenced txout in the set of spent transactions
+    // TODO: optimize this by walking the previous tx set only once ?
+    fn get_prev_script_and_value<'a>(
+        prevout: &OutPoint,
+        transactions: &'a [&impl RevaultTransaction],
+    ) -> Option<(&'a [u8], u64)> {
+        for prev_tx in transactions {
+            let tx = prev_tx.inner_tx();
+            if tx.txid() == prevout.txid {
+                return tx
+                    .output
+                    .get(prevout.vout as usize)
+                    .and_then(|txo| Some((txo.script_pubkey.as_bytes(), txo.value)));
+            }
+        }
+
+        None
+    }
+
+    for (index, txin) in revault_tx.inner_tx().input.iter().enumerate() {
+        match get_prev_script_and_value(&txin.previous_output, &previous_transactions) {
+            Some((ref raw_script_pubkey, ref value)) => {
+                if let Err(err) = bitcoinconsensus::verify(
+                    *raw_script_pubkey,
+                    *value,
+                    revault_tx.serialize().as_slice(),
+                    index,
+                ) {
+                    return Err(Error::TransactionVerification(format!(
+                        "Bitcoinconsensus error: {:?}",
+                        err
+                    )));
+                }
+            }
+            None => {
+                return Err(Error::TransactionVerification(format!(
+                    "Unknown txout refered by txin '{:?}'",
+                    txin
+                )));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -453,8 +453,9 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for RevaultInputSatisfier<Pk
         None
     }
 
-    fn check_after(&self, csv: u32) -> bool {
-        self.sequence == csv
+    fn check_older(&self, csv: u32) -> bool {
+        assert!((csv & (1 << 22) == 0));
+        self.sequence >= csv
     }
 }
 
@@ -1059,8 +1060,7 @@ mod tests {
             false,
         )
         .expect("Satisfying second spend transaction");
-        // FIXME: fix the After vs Older typo in the unvault policy
-        // assert_libbitcoinconsensus_validity!(spend_tx, [unvault_tx]);
+        assert_libbitcoinconsensus_validity!(spend_tx, [unvault_tx]);
 
         // Test that we can get the hexadecimal representation of each transaction without error
         vault_tx.hex().expect("Hex repr vault_tx");

--- a/src/txouts.rs
+++ b/src/txouts.rs
@@ -1,0 +1,77 @@
+//! Revault txouts
+//! Tiny newtype wrappers around bitcoin's TxOut to statically check Revault transaction
+//! creation.
+
+use bitcoin::TxOut;
+
+use std::fmt;
+
+/// A transaction output created by a Revault transaction.
+pub trait RevaultTxOut: fmt::Debug + Clone {
+    /// Get a reference to the inner txout
+    fn inner_txout(&self) -> &TxOut;
+    /// Get the actual inner txout
+    fn get_txout(self) -> TxOut;
+}
+
+macro_rules! implem_revault_txout {
+    ( $struct_name:ident, $doc_comment:meta ) => {
+        #[$doc_comment]
+        #[derive(Debug, Clone)]
+        pub struct $struct_name(TxOut);
+
+        impl RevaultTxOut for $struct_name {
+            fn inner_txout(&self) -> &TxOut {
+                &self.0
+            }
+
+            fn get_txout(self) -> TxOut {
+                self.0
+            }
+        }
+
+        impl $struct_name {
+            /// Create a new RevaultTxOut
+            pub fn new(txout: TxOut) -> $struct_name {
+                $struct_name(txout)
+            }
+        }
+    };
+}
+
+implem_revault_txout!(
+    VaultTxOut,
+    doc = "A vault transaction output. Used by the funding / deposit transactions, the cancel transactions, and the spend transactions (for the change)."
+);
+
+implem_revault_txout!(UnvaultTxOut, doc = "*The* unvault transaction output.");
+
+implem_revault_txout!(
+    EmergencyTxOut,
+    doc = "The Emergency Deep Vault, the destination of the emergency transactions fund."
+);
+
+implem_revault_txout!(
+    CpfpTxOut,
+    doc = "The output attached to the unvault transaction so that the fund managers can CPFP."
+);
+
+implem_revault_txout!(
+    FeeBumpTxOut,
+    doc = "The output spent by the revaulting transactions to bump their feerate"
+);
+
+implem_revault_txout!(
+    ExternalTxOut,
+    doc = "An untagged external output, as spent by the vault transaction or created by the spend transaction."
+);
+
+/// A spend transaction output can be either a change one (VaultTxOut) or a payee-controlled
+/// one (ExternalTxOut).
+pub enum SpendTxOut {
+    /// The actual destination of the funds, many such output can be present in a Spend
+    /// transaction
+    Destination(ExternalTxOut),
+    /// The change output, usually only one such output is present in a Spend transaction
+    Change(VaultTxOut),
+}


### PR DESCRIPTION
I had basically two choices for the first implem: going with traits vs going with a big enum. This was a bad choice and this refactor reverts it to The Right Thing which was to use traits. So: sorry for the big diff, but it had to be done.

This:
- Makes transactions actual types (not variants), this allows for even more type-safety.
- Creates additional trait to enforce the prevouts / txouts types at compile time.
- Expose a nicer API: no more Result (compile time :heart:)

I also found a bug as i went through this.